### PR TITLE
メッセージリストの範囲対応

### DIFF
--- a/Assets/Scenes/Game.unity
+++ b/Assets/Scenes/Game.unity
@@ -429,6 +429,14 @@ PrefabInstance:
       value: 2
       objectReference: {fileID: 0}
     - target: {fileID: 3753819723432344219, guid: 4e68e039c00e2496fafda68cfbe3cb74, type: 3}
+      propertyPath: messageList.Array.data[0]
+      value: reception[1:4]
+      objectReference: {fileID: 0}
+    - target: {fileID: 3753819723432344219, guid: 4e68e039c00e2496fafda68cfbe3cb74, type: 3}
+      propertyPath: messageList.Array.data[1]
+      value: reception[5:100]
+      objectReference: {fileID: 0}
+    - target: {fileID: 3753819723432344219, guid: 4e68e039c00e2496fafda68cfbe3cb74, type: 3}
       propertyPath: messageList.Array.data[0].turn
       value: 3
       objectReference: {fileID: 0}
@@ -2470,7 +2478,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 1, y: 0.5}
   m_AnchorMax: {x: 1, y: 0.5}
-  m_AnchoredPosition: {x: 175, y: -29.999998}
+  m_AnchoredPosition: {x: 174.99994, y: -29.999998}
   m_SizeDelta: {x: 350, y: 7}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &245910594
@@ -4001,6 +4009,14 @@ PrefabInstance:
       value: 2
       objectReference: {fileID: 0}
     - target: {fileID: 3753819723432344219, guid: 4e68e039c00e2496fafda68cfbe3cb74, type: 3}
+      propertyPath: messageList.Array.data[0]
+      value: pachi[5:6]
+      objectReference: {fileID: 0}
+    - target: {fileID: 3753819723432344219, guid: 4e68e039c00e2496fafda68cfbe3cb74, type: 3}
+      propertyPath: messageList.Array.data[1]
+      value: pachi2[7:100]
+      objectReference: {fileID: 0}
+    - target: {fileID: 3753819723432344219, guid: 4e68e039c00e2496fafda68cfbe3cb74, type: 3}
       propertyPath: messageList.Array.data[0].turn
       value: 5
       objectReference: {fileID: 0}
@@ -4395,7 +4411,7 @@ MonoBehaviour:
   m_HandleRect: {fileID: 530461694}
   m_Direction: 0
   m_Value: 0
-  m_Size: 0.99999994
+  m_Size: 1
   m_NumberOfSteps: 0
   m_OnValueChanged:
     m_PersistentCalls:
@@ -4698,7 +4714,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0.5}
   m_AnchorMax: {x: 0, y: 0.5}
-  m_AnchoredPosition: {x: -175, y: 143}
+  m_AnchoredPosition: {x: -174.99994, y: 143}
   m_SizeDelta: {x: 350, y: 7}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &514861146
@@ -10845,7 +10861,7 @@ MonoBehaviour:
   resumeOnLoad: 1
 --- !u!114 &600661001
 MonoBehaviour:
-  m_ObjectHideFlags: 0
+  m_ObjectHideFlags: 2
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
@@ -16112,7 +16128,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 3124982104124291230, guid: d24c6d558d7bb458189145bf6ee638ca, type: 3}
       propertyPath: m_Enabled
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 3124982104124291230, guid: d24c6d558d7bb458189145bf6ee638ca, type: 3}
       propertyPath: messageList.Array.size
@@ -21057,6 +21073,10 @@ PrefabInstance:
     - target: {fileID: 2094827918355497756, guid: 4e68e039c00e2496fafda68cfbe3cb74, type: 3}
       propertyPath: m_Name
       value: Adventurer
+      objectReference: {fileID: 0}
+    - target: {fileID: 3753819723432344219, guid: 4e68e039c00e2496fafda68cfbe3cb74, type: 3}
+      propertyPath: m_Enabled
+      value: 0
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 4e68e039c00e2496fafda68cfbe3cb74, type: 3}

--- a/Assets/Scripts/MessageUpdater.cs
+++ b/Assets/Scripts/MessageUpdater.cs
@@ -1,34 +1,62 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
-using System.Linq;
 using UnityEngine;
 
 public class MessageUpdater : MonoBehaviour
 {
     [SerializeField] private MessageTrigger messageTrigger;
 
-    // ターン別メッセージリスト
-    [Serializable]
-    public class SerializableKeyPair<TKey, TValue>
-    {
-        [Tooltip("このメッセージが適用されるターン")]
-        [SerializeField] private TKey turn;
-        [Tooltip("このターンに適用されるメッセージ")]
-        [SerializeField] private TValue message;
+    // messageListの書式設定
+    // reception[2:5]
+    // reception[2,6,8]
+    // reception[2]
+    public List<string> messageList;
 
-        public TKey Key => turn;
-        public TValue Value => message;
-    }
-
-    [SerializeField] private SerializableKeyPair<string,string>[] messageList = default;
-
-    // インスペクターのターン別メッセージリストをDictonaryに変換
-    private Dictionary<string, string> _messageListDictionary;
-    private Dictionary<string, string> messageListDictonary => _messageListDictionary ??= messageList.ToDictionary(p => p.Key, p => p.Value);
-
+    private Dictionary<int,string> messageListDictionary = new Dictionary<int, string>();
 
     private GameManager gameManager;
+
+    private void initMessageList() 
+    {
+        foreach (string text in messageList)
+        {
+            string message = "";
+            int startId = 0;
+
+            // Messageを見つける
+            for (int i = 0; i < text.Length; i++)
+            {
+                if (text[i] == '[')
+                {
+                    startId = i+1;
+                    break;
+                }
+                message += text[i];
+            }
+
+            // ここでmessageListの書式を判定する
+            int pattern = text.Contains(":") ? 1 : text.Contains(",") ? 2 : 3;
+
+            switch (pattern)
+            {
+                case 1:
+                    string[] range = text.Substring(startId, text.Length-startId-1).Split(':');
+                    int start = int.Parse(range[0]);
+                    int end = int.Parse(range[1]);
+                    for (int id1 = start; id1 <= end; id1++) messageListDictionary[id1] = message;
+                    break;
+                case 2:
+                    string[] ids = text.Substring(startId, text.Length-startId-1).Split(',');
+                    foreach (string id2 in ids) messageListDictionary[int.Parse(id2)] = message;
+                    break;
+                case 3:
+                    int id3 = int.Parse(text.Substring(startId, text.Length-startId-1));
+                    messageListDictionary[id3] = message;
+                    break;
+            }
+        }
+    }
 
     // Start is called before the first frame update
     void Start()
@@ -37,6 +65,8 @@ public class MessageUpdater : MonoBehaviour
         gameManager = gameManagerObject.GetComponent<GameManager>();
 
         gameManager.onTurnUpdate.AddListener(UpdateMessage);
+
+        initMessageList();
     }
 
     // MessageTriggerのmessageを更新する
@@ -60,9 +90,9 @@ public class MessageUpdater : MonoBehaviour
         string message;
 
         // ターンに対応したメッセージを返す
-        if (messageListDictonary.ContainsKey(turn.ToString()))
+        if (messageListDictionary.ContainsKey(turn))
         {
-            message = messageListDictonary[turn.ToString()];
+            message = messageListDictionary[turn];
         }
         else
         {


### PR DESCRIPTION
`MessageUpdater.cs` にて、`turn`と`message`の紐づけの範囲対応を行いました。
具体的には、
- `reception[2:5]`（ターンが2~5までreceptionのメッセージ）
- `reception[2,6,8]`（ターンが2,6,8のとき、receptionのメッセージ）
- `reception[4]`（ターンが4のとき、receptionのメッセージ）

の3パターンに対応しています。

エラーハンドリングは実装していませんが、使用頻度が高そうであるなら実装するかもしれません。

Close #11 