### PR TITLE
AreaInfoが表示されない不具合を解消

### DIFF
--- a/Assets/Scripts/InteractionTrigger.cs
+++ b/Assets/Scripts/InteractionTrigger.cs
@@ -42,7 +42,7 @@ public class InteractionTrigger : MonoBehaviour
     }
 
     // インタラクト可能かどうか
-    public virtual bool CanInteract()
+    public bool CanInteract()
     {
         return interactable && inCollision;
     }

--- a/Assets/Scripts/MessageTrigger.cs
+++ b/Assets/Scripts/MessageTrigger.cs
@@ -40,12 +40,6 @@ public class MessageTrigger : InteractionTrigger
         onInteract.AddListener(InvokeBlock);
     }
 
-    public override bool CanInteract()
-    {
-        // メッセージが空で無いことを条件に加える
-        return base.CanInteract() && message != "";
-    }
-
     // Fungusのブロックを実行する
     IEnumerator SendMessage(Action callback)
     {
@@ -91,6 +85,12 @@ public class MessageTrigger : InteractionTrigger
 
     public void InvokeBlock()
     {
+        // メッセージが空なら実行しない
+        if (message == "")
+        {
+            return;
+        }
+        
         playerController.DisableCanMove();
 
         StartCoroutine(SendMessage(() => {


### PR DESCRIPTION
#23 の不具合解消です
メッセージが空の場合はスキップする処理を書いていたため、メッセージが空だったAreaの表示が出なかったようです。

メッセージが空の場合はスキップ → メッセージが空の場合はメッセージ送信だけスキップ
に修正して解消。

動作確認済みです。